### PR TITLE
Add changes to saadi report and update renewal plan year generation

### DIFF
--- a/script/queries/generate_renewal_plan_years.rb
+++ b/script/queries/generate_renewal_plan_years.rb
@@ -1,13 +1,16 @@
-clone_start_date = Date.new(2015,2,1) # This is the 2014 date plan year start for who needs to be renewed. 
+clone_start_date = Date.new(2015,3,1) # This is the 2014 date plan year start for who needs to be renewed. 
 
-new_start_date = Date.new(2016,2,1) # This is the new plan year. 
-new_end_date = Date.new(2017,1,31) # This is the end of the plan year. 
+new_start_date = Date.new(2016,3,1) # This is the new plan year. 
+new_end_date = Date.new(2017,2,28) # This is the end of the plan year. 
 
 plan_years = PlanYear.where(:start_date => clone_start_date)
 
 count = 0
 
+feins = %w()
+
 plan_years.each do |plan_year|
+  next if feins.include?(plan_year.employer.fein) == false
   count += 1
   conflicts = plan_year.employer.plan_years.detect{ |py| py.start_date == new_start_date}
   if conflicts

--- a/script/queries/saadi_report.rb
+++ b/script/queries/saadi_report.rb
@@ -29,17 +29,17 @@ def last_payment(policy)
   if count == 0
     return "No Premium Payments"
   elsif count == 1
-    return policy.premium_payments.last.paid_at
+    return policy.premium_payments.last
   elsif count > 1
     last_payment = policy.premium_payments.to_a.sort_by!{|premium_payment| premium_payment.paid_at}.last
-    return last_payment.paid_at
+    return last_payment
   end
 end
 
 timestamp = Time.now.strftime('%Y%m%d%H%M')
 
 CSV.open("saadi_report_#{timestamp}.csv", 'w') do |csv|
-  csv << ["Enrollment Group ID", "Status", "Authority", "Policy ID", "Number of Transactions", "Sponsor", "Employer FEIN", "Premium Total", "Contribution/APTC", "Total Responsible", "Coverage Type", "Plan HIOS ID", "Plan Name", "Carrier Name", "HBX Id", "Subscriber", "First", "Middle", "Last", "DOB", "SSN", "Gender", "Start", "End", "Updated At", "Last Premium Payment"]
+  csv << ["Enrollment Group ID", "Status", "Authority", "Policy ID", "Number of Transactions", "Sponsor", "Employer FEIN", "Premium Total", "Contribution/APTC", "Total Responsible", "Coverage Type", "Plan HIOS ID", "Plan Name", "Carrier Name", "HBX Id", "Subscriber", "First", "Middle", "Last", "DOB", "SSN", "Gender", "Start", "End", "Updated At", "Last Premium Payment Date", "Last Premium Payment Amount"]
   policies.each_slice(25) do |pols|
     used_policies = pols.reject { |pl| bad_eg_id(pl) }
     member_ids = pols.map(&:enrollees).flatten.map(&:m_id)
@@ -58,6 +58,10 @@ CSV.open("saadi_report_#{timestamp}.csv", 'w') do |csv|
       sponsor = pol.employer.blank? ? "Individual" : employer_hash[pol.employer_id]
       fein = pol.try(:employer).try(:fein)
       last_prem_payment = last_payment(pol)
+      if last_prem_payment != "No Premium Payments"
+        paid_at = last_prem_payment.paid_at
+        paid_amount = (last_prem_payment.pmt_amt.to_d)/100.to_d
+      end
       csv_transactions = pol.csv_transactions.count
       other_transactions = pol.transaction_set_enrollments.count
       all_transactions = csv_transactions + other_transactions
@@ -66,7 +70,7 @@ CSV.open("saadi_report_#{timestamp}.csv", 'w') do |csv|
         per = members_map[en.m_id].last
         pol.is_shop? ? contribution = pol.employer_contribution : contribution = pol.applied_aptc
         pol.is_shop? ? sponsor = pol.employer.name : sponsor = "IVL"
-        csv << [pol.eg_id, pol.aasm_state, member.authority?, pol._id, sponsor, fein, all_transactions, pol.total_premium_amount,contribution,pol.total_responsible_amount,plan.coverage_type ,plan.hios_plan_id, plan.name, carrier.name, en.m_id, en.subscriber?, per.name_first, per.name_middle, per.name_last, member.dob.strftime("%Y%m%d"), member.ssn, member.gender, en.coverage_start.strftime("%m-%d-%Y"), (en.coverage_end.strftime("%m-%d-%Y") unless en.coverage_end.blank?),pol.updated_at.strftime("%m-%d-%Y %I:%M:%S %p %Z"), last_prem_payment]
+        csv << [pol.eg_id, pol.aasm_state, member.authority?, pol._id, sponsor, fein, all_transactions, pol.total_premium_amount,contribution,pol.total_responsible_amount,plan.coverage_type ,plan.hios_plan_id, plan.name, carrier.name, en.m_id, en.subscriber?, per.name_first, per.name_middle, per.name_last, member.dob.strftime("%Y%m%d"), member.ssn, member.gender, en.coverage_start.strftime("%m-%d-%Y"), (en.coverage_end.strftime("%m-%d-%Y") unless en.coverage_end.blank?),pol.updated_at.strftime("%m-%d-%Y %I:%M:%S %p %Z"), paid_at, paid_amount.to_s]
       end
     end
   end


### PR DESCRIPTION
- renewal plan year generation will now require you to put in a list of FEINs before generating renewal plan years. 

- saadi report will now reflect last amount of payment. 