### PR TITLE
Refs #6045 Correction since .legal_name is not a valid field

### DIFF
--- a/app/models/canonical_vocabulary/enrollment_serializer.rb
+++ b/app/models/canonical_vocabulary/enrollment_serializer.rb
@@ -61,7 +61,7 @@ module CanonicalVocabulary
       emp = employer_lookup(@policy)
       if !emp.nil?
         xml['emp'].employer do |xml|
-          xml['emp'].name(emp.dba.blank?  ? emp.legal_name : emp.dba)
+          xml['emp'].name(emp.dba.blank?  ? emp.name : emp.dba)
           xml['emp'].exchange_employer_id(emp.hbx_id)
           xml['emp'].fein(emp.fein)
         end


### PR DESCRIPTION
@TreyE I realized that .legal_name would fail for CVs since the correct name of the field is actually "name". This fix changes that. 