### PR TITLE
fix address serializer

### DIFF
--- a/app/models/canonical_vocabulary/enrollment_serializer.rb
+++ b/app/models/canonical_vocabulary/enrollment_serializer.rb
@@ -155,7 +155,7 @@ module CanonicalVocabulary
         if mailing_address.nil?
           []
         else
-          mailing_address
+          [mailing_address]
         end
       else
         if mailing_address.nil?


### PR DESCRIPTION
Has the address_serializer return a mailing address only to resolve type errors. 