### PR TITLE
Refs #8056 Refs #10931 glue code to add discrepant hbx ids and feins

### DIFF
--- a/script/queries/glue_enroll_employer_hbx_id_discrepancy.rb
+++ b/script/queries/glue_enroll_employer_hbx_id_discrepancy.rb
@@ -1,0 +1,28 @@
+enroll_input_file = 'employer_list.csv' # The filename of the file coming from enroll
+
+csv_rows = []
+
+CSV.foreach(enroll_input_file,headers: true) do |enroll_row|
+	employer_fein = Employer.where(fein: enroll_row['fein']).to_a
+	glue_hbx_id = employer_fein.map(&:hbx_id).uniq.join(";")
+	if glue_hbx_id != enroll_row['hbx_id']
+		enroll_row['glue_hbx_id'] = glue_hbx_id
+	else
+		enroll_row['glue_hbx_id'] = ""
+	end
+	employer_hbx_id = Employer.where(hbx_id: enroll_row['hbx_id']).to_a
+	glue_fein = employer_hbx_id.map(&:fein).uniq.join(";")
+	if glue_fein != enroll_row['fein']
+		enroll_row['glue_fein'] = glue_fein
+	else
+		enroll_row['glue_fein'] = ""
+	end
+	csv_rows.push(enroll_row)
+end
+
+CSV.open("#{enroll_input_file.gsub(".csv","")}_with_glue_data.csv","w") do |csv|
+	csv << ["employer_legal_name","fein","dba","hbx_id","glue_hbx_id (if different)","glue_fein (if different)"]
+	csv_rows.each do |csv_row|
+		csv << csv_row
+	end
+end


### PR DESCRIPTION
### Redmine ticket(s)
* https://devops.dchbx.org/redmine/issues/10931
* https://devops.dchbx.org/redmine/issues/8056

### Local build result
```
rspec
Finished in 9.7 seconds (files took 6.13 seconds to load)
1117 examples, 2 failures, 14 pending
```

### Latest rebase/merge tag
*3.3.0

### TODOs / Notes
#### Peer Review
The ticket requests that we find discrepant HBX IDs for the same FEIN. I've taken the liberty of also checking in the other direction (e.g., different FEINs for the same HBX ID) as these would also be a concern.
The script should produce a CSV with two columns added, one for discrepant HBX IDs, one for discrepant FEINs.

#### Functional Testing
This script only needs to be run on Glue Preprod or with a copy of Glue data.

#### Deployment
Script would be run as follows:
```
bundle exec rails r script/queries/glue_enroll_employer_hbx_id_discrepancy.rb -e production
```