### PR TITLE
Bug 7624 Subscribers with No Addresses and potential previous addresses

### DIFF
--- a/script/queries/subscribers_no_addresses.rb
+++ b/script/queries/subscribers_no_addresses.rb
@@ -1,0 +1,39 @@
+# Finds all subscribers with no home address.
+puts "Started at #{Time.now}"
+
+subscriber_ids = []
+
+Policy.all.each do |policy|
+	next if policy.subscriber.blank?
+	subscriber_ids.push(policy.subscriber.m_id)
+end
+
+subscriber_ids.uniq!
+
+subscribers = Person.where("members.hbx_member_id" => {"$in" => subscriber_ids})
+
+puts "Subscribers collected at #{Time.now}"
+
+def find_previous_home_addresses(person)
+	return [] if person.versions.blank?
+	addresses = person.versions.map(&:home_address).compact.uniq.map(&:full_address).uniq
+	return addresses
+end
+
+CSV.open("people_missing_addresses_#{Time.now.strftime('%Y%m%d%H%M')}.csv", "w") do |csv|
+	csv << ["HBX ID", "First Name", "Middle Name", "Last Name", "Previous Home Addresses"]
+	subscribers.each do |subscriber|
+		if subscriber.home_address.blank?
+			hbx_id = subscriber.authority_member_id
+			first_name = subscriber.name_first
+			middle_name = subscriber.name_middle
+			last_name = subscriber.name_last
+			previous_addresses = find_previous_home_addresses(subscriber).join('; ')
+			csv << [hbx_id,first_name,middle_name,last_name,previous_addresses]
+		else
+			next
+		end
+	end
+end
+
+puts "Finished at #{Time.now}"

--- a/spec/script/queries/subscribers_no_addresses_spec.rb
+++ b/spec/script/queries/subscribers_no_addresses_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+require File.join(Rails.root, "script", "queries", "subscribers_no_addresses")
+
+describe 'find_previous_home_addresses' do
+	it 'should return an empty array if the person has not been updated' do
+		person = FactoryGirl.create :person
+		expect(find_previous_home_addresses(person)).to eq []
+	end
+
+	it 'should return an array of strings if the person has been updated' do
+		person = FactoryGirl.create :person
+		person.remove_address_of('home')
+		expect(find_previous_home_addresses(person).map(&:class).to_s).to eq 'String'
+	end
+end

--- a/spec/script/queries/subscribers_no_addresses_spec.rb
+++ b/spec/script/queries/subscribers_no_addresses_spec.rb
@@ -9,7 +9,11 @@ describe 'find_previous_home_addresses' do
 
 	it 'should return an array of strings if the person has been updated' do
 		person = FactoryGirl.create :person
-		person.remove_address_of('home')
-		expect(find_previous_home_addresses(person).map(&:class).to_s).to eq 'String'
+    person.name_first = "James"
+    person.save!
+    person.remove_address_of('home')
+    person.save!
+    person = Person.where(name_first: "James").first
+		expect(find_previous_home_addresses(person).map(&:class).uniq.first.to_s).to eq 'String'
 	end
 end


### PR DESCRIPTION
### Master Redmine ticket
* https://devops.dchbx.org/redmine/issues/7624

### Local build result
```
bundle exec rspec
Finished in 10.36 seconds (files took 6.68 seconds to load)
1169 examples, 2 failures, 14 pending
```

### Latest rebase/merge tag
* 3.3.1

---

### Data ticket(s) Followup
* (redmine links here - optional)

### Related Pull Requests
* (github links here - optional)

---

### TODOs / Notes
#### Peer Review
* This code is designed to find policy subscribers who have no addresses so that we can get the data cleaned up. 

#### Functional Testing
* This would mostly be review of the returned data to make sure it's accurate. 

#### Deployment
* command to run is 
```
bundle exec rails r script/queries/subscribers_no_addresses.rb -e production
```
