### PR TITLE
21200: Domestic Partner from EA must be mapped to Life Partner in EDI instead of Spouse

### DIFF
--- a/app/models/external_events/external_policy.rb
+++ b/app/models/external_events/external_policy.rb
@@ -92,7 +92,9 @@ module ExternalEvents
     def extract_rel_from_me(rel)
       simple_relationship = Maybe.new(rel).relationship_uri.strip.split("#").last.downcase.value
       case simple_relationship
-      when "spouse", "life_partner", "domestic_partner"
+      when "life_partner", "domestic_partner"
+        "life partner"
+      when "spouse"
         "spouse"
       when "ward"
         "ward"
@@ -104,7 +106,9 @@ module ExternalEvents
     def extract_rel_from_sub(rel)
       simple_relationship = Maybe.new(rel).relationship_uri.strip.split("#").last.downcase.value
       case simple_relationship
-      when "spouse", "life_partner", "domestic_partner"
+      when "life_partner", "domestic_partner"
+        "life partner"
+      when "spouse"
         "spouse"
       when "court_appointed_guardian"
         "ward"

--- a/app/models/external_events/external_policy_member_add.rb
+++ b/app/models/external_events/external_policy_member_add.rb
@@ -54,7 +54,9 @@ module ExternalEvents
     def extract_rel_from_me(rel)
       simple_relationship = Maybe.new(rel).relationship_uri.strip.split("#").last.downcase.value
       case simple_relationship
-      when "spouse", "life_partner", "domestic_partner"
+      when "life_partner", "domestic_partner"
+        "life partner"
+      when "spouse"
         "spouse"
       when "ward"
         "ward"
@@ -66,7 +68,9 @@ module ExternalEvents
     def extract_rel_from_sub(rel)
       simple_relationship = Maybe.new(rel).relationship_uri.strip.split("#").last.downcase.value
       case simple_relationship
-      when "spouse", "life_partner", "domestic_partner"
+      when "life_partner", "domestic_partner"
+        "life partner"
+      when "spouse"
         "spouse"
       when "court_appointed_guardian"
         "ward"


### PR DESCRIPTION
|Field|Value|
|-----|-----|
| Redmine Ticket Number | [21200](https://devops.dchbx.org/redmine/issues/21200) |
| App-Dev Road Map # | n/a |
| Start Date | n/a |
| Due Date | n/a  |
| App-Dev Priority | UP-Disqueued |
| Development Story Points | n/a |
| Peer Review Story Points | n/a |
| Ticket Author | Saadi Mirza |