### PR TITLE
Fix policies missing transmissions

### DIFF
--- a/lib/tasks/change_policy_end_date.rake
+++ b/lib/tasks/change_policy_end_date.rake
@@ -1,7 +1,7 @@
 require File.join(Rails.root,"app","data_migrations","change_policy_end_date.rb")
 
 # This rake tasks removes end dates from all members of a policy in Glue. 
-# format RAILS_ENV = production bundle exec rake migrations:change_policy_end_date eg_id='123456' end_date='05/31/2017'
+# format RAILS_ENV=production bundle exec rake migrations:change_policy_end_date eg_id='123456' end_date='05/31/2017'
 
 namespace :migrations do 
   desc "Change Policy End Date"

--- a/lib/tasks/remove_policy_end_date.rake
+++ b/lib/tasks/remove_policy_end_date.rake
@@ -1,7 +1,7 @@
 require File.join(Rails.root,"app","data_migrations","remove_policy_end_date.rb")
 
 # This rake tasks removes end dates from all members of a policy in Glue. 
-# format RAILS_ENV = production bundle exec rake migrations:remove_policy_end_date aasm_state='submitted' eg_id='123456'
+# format RAILS_ENV=production bundle exec rake migrations:remove_policy_end_date aasm_state='submitted' eg_id='123456'
 
 namespace :migrations do 
   desc "Remove Policy End Date"

--- a/script/queries/policies_missing_transmissions.rb
+++ b/script/queries/policies_missing_transmissions.rb
@@ -1,12 +1,5 @@
 ct_cache = Caches::Mongoid::SinglePropertyLookup.new(Plan, "coverage_type")
 
-p_repo = {}
-
-p_map = Person.collection.aggregate([{"$unwind"=> "$members"}, {"$project" => {"_id" => 0, member_id: "$members.hbx_member_id", person_id: "$_id"}}])
-p_map.each do |val|
-    p_repo[val["member_id"]] = val["person_id"]
-end
-
 all_pol_ids = Protocols::X12::TransactionSetHeader.collection.aggregate([
   {"$match" => {
     "policy_id" => { "$ne" => nil }


### PR DESCRIPTION
The query results from below are causing performance issues and are not used anywhere else in the report. The changes to the rake tasks are just to fix the syntax for future reference. 