### PR TITLE
32916: Update the XSD in EDI Codec to validate input CV2 with the new Cover All QLE's

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -517,4 +517,4 @@ DEPENDENCIES
   virtus
 
 BUNDLED WITH
-   1.16.5
+   1.16.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: git@github.com:dchbx/edi_codec.git
-  revision: 448f0183f6fe7da0de2c39b3e25a5c00188f137e
+  revision: 9cae104c4d9144edf9cd411d7f7ccb0a3ab888fe
   specs:
     edi_codec (0.1.2)
       activesupport (>= 3.2)
@@ -517,4 +517,4 @@ DEPENDENCIES
   virtus
 
 BUNDLED WITH
-   1.16.2
+   1.16.5


### PR DESCRIPTION
|Field|Value|
|-----|-----|
| Redmine Ticket Number | [32916](https://devops.dchbx.org/redmine/issues/32916) |
| App-Dev Road Map # | n/a |
| Start Date | n/a |
| Due Date | n/a  |
| App-Dev Priority | UP-Disqueued |
| Development Story Points | n/a |
| Peer Review Story Points | n/a |
| Ticket Author | @karashearer5 |