### PR TITLE
Remove notification for specific EDI case.

### DIFF
--- a/app/models/enrollment_action/carrier_switch.rb
+++ b/app/models/enrollment_action/carrier_switch.rb
@@ -21,8 +21,9 @@ module EnrollmentAction
       ep = ExternalEvents::ExternalPolicy.new(action.policy_cv, action.existing_plan, action.is_cobra?, market_from_payload: action.kind)
       return false unless ep.persist
       policy_to_term = termination.existing_policy
+      existing_npt = policy_to_term.term_for_np
       result = policy_to_term.terminate_as_of(termination.subscriber_end)
-      unless termination_event_exempt_from_notification?(policy_to_term, termination.subscriber_end)
+      unless termination_event_exempt_from_notification?(policy_to_term, termination.subscriber_end, true, existing_npt)
         Observers::PolicyUpdated.notify(policy_to_term)
       end
       result

--- a/app/models/enrollment_action/carrier_switch_renewal.rb
+++ b/app/models/enrollment_action/carrier_switch_renewal.rb
@@ -20,8 +20,9 @@ module EnrollmentAction
         [t_pol, t_pol.active_member_ids]
       end
       termination_results = termination_candidates.map do |rc|
+        existing_npt = rc.term_for_np
         term_result = rc.terminate_as_of(action.subscriber_start - 1.day)
-        unless termination_event_exempt_from_notification?(rc, action.subscriber_start - 1.day)
+        unless termination_event_exempt_from_notification?(rc, action.subscriber_start - 1.day, true, existing_npt)
           Observers::PolicyUpdated.notify(rc)
         end
         term_result

--- a/app/models/enrollment_action/market_change.rb
+++ b/app/models/enrollment_action/market_change.rb
@@ -21,8 +21,9 @@ module EnrollmentAction
       ep = ExternalEvents::ExternalPolicy.new(action.policy_cv, action.existing_plan, action.is_cobra?, market_from_payload: action.kind)
       return false unless ep.persist
       policy_to_term = termination.existing_policy
+      existing_npt = policy_to_term.term_for_np
       result = policy_to_term.terminate_as_of(termination.subscriber_end)
-      unless termination_event_exempt_from_notification?(policy_to_term, termination.subscriber_end)
+      unless termination_event_exempt_from_notification?(policy_to_term, termination.subscriber_end, true, existing_npt)
         Observers::PolicyUpdated.notify(policy_to_term)
       end
       result

--- a/app/models/enrollment_action/notification_exemption_helper.rb
+++ b/app/models/enrollment_action/notification_exemption_helper.rb
@@ -1,5 +1,13 @@
 module EnrollmentAction
   module NotificationExemptionHelper
+
+    # Determine if notification should be sent for a termination.
+    #
+    # @param policy [Policy] the policy in question, after termination
+    # @param termination_date [Date] the scheduled termination date
+    # @param check_npt_change [Boolean] check if the NPT flag has changed
+    # @param old_npt_val [Boolean] the value of the NPT flag prior to the change
+    # @return [Boolean]
     def termination_event_exempt_from_notification?(policy, termination_date, check_npt_change = false, old_npt_val = nil)
       return false if policy.is_shop?
       if check_npt_change

--- a/app/models/enrollment_action/notification_exemption_helper.rb
+++ b/app/models/enrollment_action/notification_exemption_helper.rb
@@ -1,29 +1,11 @@
 module EnrollmentAction
   module NotificationExemptionHelper
-
-    def termination_event_exempt_from_notification?(policy, termination_date)
+    def termination_event_exempt_from_notification?(policy, termination_date, check_npt_change = false, old_npt_val = nil)
       return false if policy.is_shop?
-      formated_date = format_string_to_date(termination_date)
-      (formated_date.month == 12) && (formated_date.day == 31) && check_for_npt_flag_end_date(policy)
-    end
-
-    def format_string_to_date(date)
-      return date if date.class == Date
-      if date.split('/').first.size == 2
-        Date.strptime(date,"%m/%d/%Y")
-      elsif date.split('-').first.size == 2
-        Date.strptime(date,"%m-%d-%Y")
+      if check_npt_change
+        return false if (old_npt_val != policy.term_for_np)
       end
-    end
-
-    def check_for_npt_flag_end_date(policy)
-      #new policy will not have prior versions
-      if policy.versions.present?
-        before_updated_policy = policy.versions.order_by(updated_at: :desc).first
-        before_updated_policy.policy_end.nil? && (policy.term_for_np == before_updated_policy.term_for_np)
-      else
-        false
-      end
+      (termination_date.month == 12) && (termination_date.day == 31)
     end
   end
 end

--- a/app/models/enrollment_action/termination.rb
+++ b/app/models/enrollment_action/termination.rb
@@ -13,8 +13,9 @@ module EnrollmentAction
     def persist
       if termination.existing_policy
         policy_to_term = termination.existing_policy
+        existing_npt = policy_to_term.term_for_np
         result = policy_to_term.terminate_as_of(termination.subscriber_end)
-        unless termination_event_exempt_from_notification?(policy_to_term, termination.subscriber_end)
+        unless termination_event_exempt_from_notification?(policy_to_term, termination.subscriber_end, true, existing_npt)
           Observers::PolicyUpdated.notify(policy_to_term)
         end
         return result

--- a/app/models/external_events/enrollment_event_notification.rb
+++ b/app/models/external_events/enrollment_event_notification.rb
@@ -264,6 +264,9 @@ module ExternalEvents
       @subscriber_start ||= extract_enrollee_start(subscriber)
     end
 
+    # Provides the subscriber end date from the event.
+    #
+    # @return [Date, nil] the extracted end date
     def subscriber_end
       @subscriber_end ||= extract_enrollee_end(subscriber)
     end

--- a/app/models/external_events/external_policy_member_drop.rb
+++ b/app/models/external_events/external_policy_member_drop.rb
@@ -192,7 +192,7 @@ module ExternalEvents
     def member_exempt_from_termination_notification?(pol, enrollee_node)
       end_date = extract_enrollee_end(enrollee_node)
       return false if end_date.blank?
-      termination_event_exempt_from_notification?(pol, end_date)
+      termination_event_exempt_from_notification?(pol, end_date, false)
     end
   end
 end

--- a/app/models/parsers/edi/transmission_file.rb
+++ b/app/models/parsers/edi/transmission_file.rb
@@ -178,23 +178,7 @@ module Parsers
           policy.merge_enrollee(enrollee, policy_loop.action)
         end
         policy.save!
-        unless termination_event_exempt_from_notification?(policy)
-          Observers::PolicyUpdated.notify(policy)
-        end
         policy
-      end
-
-      def termination_event_exempt_from_notification?(policy)
-        if @before_updated_policy.present?
-          @updated_policy = policy
-          #Policy End Date change - null to 12/31 AND no NPT indicator change (don't notify)
-          #Dependent Only End Date Change - null to 12/31 AND no NPT status change (don't notify)
-          is_npt_flag_same? && is_dependent_coverage_end_change_to_end_of_year?
-        end
-      end
-
-      def is_npt_flag_same?
-        @updated_policy.term_for_np == @before_updated_policy.term_for_np
       end
 
       def is_dependent_coverage_end_change_to_end_of_year?

--- a/spec/models/enrollment_action/carrier_switch_spec.rb
+++ b/spec/models/enrollment_action/carrier_switch_spec.rb
@@ -59,6 +59,7 @@ describe EnrollmentAction::CarrierSwitch, "given a qualified enrollment set, bei
   end
 
   before :each do
+    allow(policy).to receive(:term_for_np).and_return(false)
     allow(ExternalEvents::ExternalMember).to receive(:new).with(member_primary).and_return(primary_db_record)
     allow(ExternalEvents::ExternalMember).to receive(:new).with(member_secondary).and_return(secondary_db_record)
     allow(ExternalEvents::ExternalMember).to receive(:new).with(member_new).and_return(new_db_record)

--- a/spec/models/enrollment_action/market_change_spec.rb
+++ b/spec/models/enrollment_action/market_change_spec.rb
@@ -76,11 +76,13 @@ describe EnrollmentAction::MarketChange, "given a qualified enrollment set, bein
   end
 
   it "notifies of the termination" do
+    allow(policy).to receive(:term_for_np).and_return(false)
     expect(Observers::PolicyUpdated).to receive(:notify).with(policy)
     subject.persist
   end
 
   it "successfully creates the new policy" do
+    allow(policy).to receive(:term_for_np).and_return(false)
     expect(subject.persist).to be_truthy
   end
 
@@ -89,6 +91,7 @@ describe EnrollmentAction::MarketChange, "given a qualified enrollment set, bein
     let(:subscriber_end) { Date.new(2015, 5, 31) }
 
     it "notifies of the termination" do
+      allow(policy).to receive(:term_for_np).and_return(true)
       expect(Observers::PolicyUpdated).to receive(:notify).with(policy)
       subject.persist
     end
@@ -98,9 +101,20 @@ describe EnrollmentAction::MarketChange, "given a qualified enrollment set, bein
     let(:is_shop) { false }
     let(:subscriber_end) { Date.new(2015, 12, 31) }
 
-    it "notifies of the termination" do
-      allow(subject).to receive(:check_for_npt_flag_end_date).with(policy).and_return(true)
+    it "doesn't notify of the termination" do
+      allow(policy).to receive(:term_for_np).and_return(true)
       expect(Observers::PolicyUpdated).not_to receive(:notify).with(policy)
+      subject.persist
+    end
+  end
+
+  describe "given IVL with end date of 12/31, but a changed NPT" do
+    let(:is_shop) { false }
+    let(:subscriber_end) { Date.new(2015, 12, 31) }
+
+    it "notifies of the termination" do
+      allow(policy).to receive(:term_for_np).and_return(true, false)
+      expect(Observers::PolicyUpdated).to receive(:notify).with(policy)
       subject.persist
     end
   end

--- a/spec/models/enrollment_action/notification_exemption_helper_spec.rb
+++ b/spec/models/enrollment_action/notification_exemption_helper_spec.rb
@@ -5,7 +5,7 @@ describe EnrollmentAction::NotificationExemptionHelper, :dbclean => :after_each 
 
   describe "termination_event_exempt_from_notification?" do
     let(:current_year) { ((today.beginning_of_year)..today.end_of_year) }
-    let!(:termination_date1) {"12/31/2019"}
+    let!(:termination_date1) {Date.new(2019, 12, 31) }
     let!(:termination_date2) {"12-31-2019"}
     let!(:termination_date3) {"10/31/2019"}
     let!(:termination_date4) {"10-31-2019"}
@@ -46,64 +46,23 @@ describe EnrollmentAction::NotificationExemptionHelper, :dbclean => :after_each 
       end
     end
 
-    context "given a IVL policy with termination date format" do
-      let(:policy) do
-        instance_double(
-          Policy,
-          is_shop?: false,
-          kind: 'individual',
-          coverage_type: "health"
-        )
-      end
-
-      before :each do
-        allow(subject).to receive(:check_for_npt_flag_end_date).with(policy).and_return(true)
-      end
-
-      it "return true when termination date is sent i.e 12/31/2019(%m/%d/%Y)" do
-        expect(subject.termination_event_exempt_from_notification?(policy, termination_date1)).to be_truthy
-      end
-
-      it "return false when termination date is sent i.e 10/31/2019(%m/%d/%Y)" do
-        expect(subject.termination_event_exempt_from_notification?(policy, termination_date3)).to be_false
-      end
-
-      it "return true when termination date is sent i.e 12-31-2019(%m-%d-%Y)" do
-        expect(subject.termination_event_exempt_from_notification?(policy, termination_date2)).to be_truthy
-      end
-
-      it "return false when termination date is sent i.e 10-31-2019(%m-%d-%Y)" do
-        expect(subject.termination_event_exempt_from_notification?(policy, termination_date4)).to be_false
-      end
-    end
-
-    context 'when there is no IVL policy versions present' do
-      it "return false" do
-        expect(policy.is_shop?).to eq false
-        expect(policy.coverage_type).to eq "health"
-        policy.subscriber.update_attributes!(coverage_end: "12/31/2019")
-        expect(policy.versions.present?).to eq false
-        expect(subject.termination_event_exempt_from_notification?(policy, termination_date1)).to be_false
-      end
-    end
-
     context 'given IVL policy is terminated at 12/31/PY' do
       it "return false when NPT flag change" do
+        allow(policy).to receive(:term_for_np).and_return(true)
         expect(policy.is_shop?).to eq false
         expect(policy.coverage_type).to eq "health"
         policy.subscriber.update_attributes!(coverage_end: "12/31/2019")
         policy.update_attributes!(term_for_np: true)
         policy.save!
-        expect(subject.termination_event_exempt_from_notification?(policy, termination_date1)).to be_false
+        expect(subject.termination_event_exempt_from_notification?(policy, termination_date1, true, false)).to be_false
       end
-    end
 
-    context 'given IVL policy is terminated at 12/31/PY' do
       it "return true when NPT flag won't change" do
+        allow(policy).to receive(:term_for_np).and_return(false)
         expect(policy.is_shop?).to eq false
         expect(policy.coverage_type).to eq "health"
         policy.terminate_as_of(coverage_end)
-        expect(subject.termination_event_exempt_from_notification?(policy, termination_date1)).to be_true
+        expect(subject.termination_event_exempt_from_notification?(policy, termination_date1, true, false)).to be_true
       end
     end
   end

--- a/spec/models/enrollment_action/renewal_dependent_drop_spec.rb
+++ b/spec/models/enrollment_action/renewal_dependent_drop_spec.rb
@@ -98,7 +98,6 @@ describe EnrollmentAction::RenewalDependentDrop, "given a qualified enrollent se
     let(:member_end_date) { Date.new(2015, 12, 31) }
 
     it "notifies of the termination" do
-      allow(subject).to receive(:check_for_npt_flag_end_date).with(old_policy).and_return(true)
       expect(Observers::PolicyUpdated).not_to receive(:notify).with(old_policy)
       subject.persist
     end

--- a/spec/models/external_events/external_policy_member_drop_spec.rb
+++ b/spec/models/external_events/external_policy_member_drop_spec.rb
@@ -146,7 +146,6 @@ describe ExternalEvents::ExternalPolicyMemberDrop, "given:
     end
 
     it "doesn't notify" do
-      allow(subject).to receive(:check_for_npt_flag_end_date).with(existing_policy).and_return(true)
       expect(Observers::PolicyUpdated).not_to receive(:notify).with(existing_policy)
       subject.persist
     end


### PR DESCRIPTION
The ONLY case in which it is possible to create a need for a
notification which would not be caught elsewhere in the process is via
CV upload in the gluedb interface.

In every other case you would be executing a 'double notify' and getting
to notices.

As the CV upload handling is out of scope of this, and given the high
chance for double-notification, I have removed notification code from
EDI import.